### PR TITLE
Remove mis-aligned colon in chapter headlines

### DIFF
--- a/content/chapters-mobile-info/chapter1.da.md
+++ b/content/chapters-mobile-info/chapter1.da.md
@@ -8,7 +8,7 @@ params:
 
 ---
 
-## Kapitel &#9737;:
+## Kapitel &#9737;
 
 ### Augmented Reality
 

--- a/content/chapters-mobile-info/chapter1.md
+++ b/content/chapters-mobile-info/chapter1.md
@@ -8,7 +8,7 @@ params:
 
 ---
 
-## Chapter &#9737;:
+## Chapter &#9737;
 
 ### Augmented Reality
 

--- a/content/chapters-mobile-info/chapter2.da.md
+++ b/content/chapters-mobile-info/chapter2.da.md
@@ -8,7 +8,7 @@ params:
 
 ---
 
-## Kapitel &#9661;:
+## Kapitel &#9661;
 
 ### Augmented Reality
 

--- a/content/chapters-mobile-info/chapter2.md
+++ b/content/chapters-mobile-info/chapter2.md
@@ -8,7 +8,7 @@ params:
 
 ---
 
-## Chapter &#9661;:
+## Chapter &#9661;
 
 ### Augmented Reality
 

--- a/content/chapters-mobile-info/chapter3.da.md
+++ b/content/chapters-mobile-info/chapter3.da.md
@@ -8,7 +8,7 @@ params:
 
 ---
 
-## Kapitel &#8516;:
+## Kapitel &#8516;
 
 ### Augmented Reality
 

--- a/content/chapters-mobile-info/chapter3.md
+++ b/content/chapters-mobile-info/chapter3.md
@@ -8,7 +8,7 @@ params:
 
 ---
 
-## Chapter &#8516;:
+## Chapter &#8516;
 
 ### Augmented Reality
 

--- a/content/map/chapters/chapter1/scene1.da.md
+++ b/content/map/chapters/chapter1/scene1.da.md
@@ -10,7 +10,7 @@ params:
   gltfsource: "/3dmodels/1_soccer_shoes/1_soccer_shoes.gltf"
 
 ---
-## Kapitel &#9737;:
+## Kapitel &#9737;
 ### Scene 1: Sko
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter1/scene1.md
+++ b/content/map/chapters/chapter1/scene1.md
@@ -10,7 +10,7 @@ params:
   gltfsource: "/3dmodels/1_soccer_shoes/1_soccer_shoes.gltf"
 
 ---
-## Chapter &#9737;:
+## Chapter &#9737;
 ### Scene 1: Soccer Shoes
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter1/scene2.da.md
+++ b/content/map/chapters/chapter1/scene2.da.md
@@ -10,7 +10,7 @@ params:
   gltfsource: "/3dmodels/2_trophy/2_trophy.gltf"
 
 ---
-## Kapitel &#9737;:
+## Kapitel &#9737;
 ### Scene 2: Trofæ
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter1/scene2.md
+++ b/content/map/chapters/chapter1/scene2.md
@@ -10,7 +10,7 @@ params:
   gltfsource: "/3dmodels/2_trophy/2_trophy.gltf"
 
 ---
-## Chapter &#9737;:
+## Chapter &#9737;
 ### Scene 2: Trophy
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter1/scene3.da.md
+++ b/content/map/chapters/chapter1/scene3.da.md
@@ -10,7 +10,7 @@ params:
   gltfsource: "/3dmodels/3_medal/3_medal.gltf"
 
 ---
-## Kapitel &#9737;:
+## Kapitel &#9737;
 ### Scene 3: Medaljer
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter1/scene3.md
+++ b/content/map/chapters/chapter1/scene3.md
@@ -10,7 +10,7 @@ params:
   gltfsource: "/3dmodels/3_medal/3_medal.gltf"
 
 ---
-## Chapter &#9737;:
+## Chapter &#9737;
 ### Scene 3: Medals
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter1/scene4.da.md
+++ b/content/map/chapters/chapter1/scene4.da.md
@@ -11,7 +11,7 @@ params:
   gltfsource: "/3dmodels/4_little_statues/4_little_statues.gltf"
 
 ---
-## Kapitel &#9737;:
+## Kapitel &#9737;
 ### Scene 4: Små statuer
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter1/scene4.md
+++ b/content/map/chapters/chapter1/scene4.md
@@ -11,7 +11,7 @@ params:
   gltfsource: "/3dmodels/4_little_statues/4_little_statues.gltf"
 
 ---
-## Chapter &#9737;:
+## Chapter &#9737;
 ### Scene 4: Little Statues
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter1/scene5.da.md
+++ b/content/map/chapters/chapter1/scene5.da.md
@@ -9,7 +9,7 @@ params:
   textures: "/3dmodels/5_bottle_opener/textures"
   gltfsource: "/3dmodels/5_bottle_opener/5_bottle_opener.gltf"
 ---
-## Kapitel &#9737;:
+## Kapitel &#9737;
 ### Scene 5: Oplukker
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter1/scene5.md
+++ b/content/map/chapters/chapter1/scene5.md
@@ -9,7 +9,7 @@ params:
   textures: "/3dmodels/5_bottle_opener/textures"
   gltfsource: "/3dmodels/5_bottle_opener/5_bottle_opener.gltf"
 ---
-## Chapter &#9737;:
+## Chapter &#9737;
 ### Scene 5: Bottle Opener
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter1/scene6.da.md
+++ b/content/map/chapters/chapter1/scene6.da.md
@@ -9,7 +9,7 @@ params:
   textures: "/3dmodels/6_painting/textures"
   gltfsource: "/3dmodels/6_painting/6_painting.gltf"
 ---
-## Kapitel &#9737;:
+## Kapitel &#9737;
 ### Scene 6: Maleri
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter1/scene6.md
+++ b/content/map/chapters/chapter1/scene6.md
@@ -9,7 +9,7 @@ params:
   textures: "/3dmodels/6_painting/textures"
   gltfsource: "/3dmodels/6_painting/6_painting.gltf"
 ---
-## Chapter &#9737;:
+## Chapter &#9737;
 ### Scene 6: Painting
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter2/scene07.da.md
+++ b/content/map/chapters/chapter2/scene07.da.md
@@ -10,7 +10,7 @@ params:
   gltfsource: "/3dmodels/7_tupilac/7_tupilac.gltf"
 
 ---
-## Kapitel &#9661;:
+## Kapitel &#9661;
 ### Scene 7: Tupilac
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter2/scene07.md
+++ b/content/map/chapters/chapter2/scene07.md
@@ -10,7 +10,7 @@ params:
   gltfsource: "/3dmodels/7_tupilac/7_tupilac.gltf"
 
 ---
-## Chapter &#9661;:
+## Chapter &#9661;
 ### Scene 7: Tupilac/Seal
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter2/scene08.da.md
+++ b/content/map/chapters/chapter2/scene08.da.md
@@ -10,7 +10,7 @@ params:
   gltfsource: "/3dmodels/8_stone/8_stone.gltf"
 
 ---
-## Kapitel &#9661;:
+## Kapitel &#9661;
 ### Scene 8: Anhangabau-sten
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter2/scene08.md
+++ b/content/map/chapters/chapter2/scene08.md
@@ -10,7 +10,7 @@ params:
   gltfsource: "/3dmodels/8_stone/8_stone.gltf"
 
 ---
-## Chapter &#9661;:
+## Chapter &#9661;
 ### Scene 8: Stone Anhangabau
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter2/scene09.da.md
+++ b/content/map/chapters/chapter2/scene09.da.md
@@ -10,7 +10,7 @@ params:
   gltfsource: "/3dmodels/9_bracelet/9_bracelet.gltf"
 
 ---
-## Kapitel &#9661;:
+## Kapitel &#9661;
 ### Scene 9: Armbånd
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter2/scene09.md
+++ b/content/map/chapters/chapter2/scene09.md
@@ -10,7 +10,7 @@ params:
   gltfsource: "/3dmodels/9_bracelet/9_bracelet.gltf"
 
 ---
-## Chapter &#9661;:
+## Chapter &#9661;
 ### Scene 9: Bracelet
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter2/scene10.da.md
+++ b/content/map/chapters/chapter2/scene10.da.md
@@ -11,7 +11,7 @@ params:
   gltfsource: "/3dmodels/4_little_statues/4_little_statues.gltf"
 
 ---
-## Kapitel &#9661;:
+## Kapitel &#9661;
 ### Scene 10: Hund
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter2/scene10.md
+++ b/content/map/chapters/chapter2/scene10.md
@@ -11,7 +11,7 @@ params:
   gltfsource: "/3dmodels/4_little_statues/4_little_statues.gltf"
 
 ---
-## Chapter &#9661;:
+## Chapter &#9661;
 ### Scene 10: Dog
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter2/scene11.da.md
+++ b/content/map/chapters/chapter2/scene11.da.md
@@ -9,7 +9,7 @@ params:
   textures: "/3dmodels/11_plant/textures"
   gltfsource: "/3dmodels/11_plant/11_plant.gltf"
 ---
-## Kapitel &#9661;:
+## Kapitel &#9661;
 ### Scene 11: Plante
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter2/scene11.md
+++ b/content/map/chapters/chapter2/scene11.md
@@ -9,7 +9,7 @@ params:
   textures: "/3dmodels/11_plant/textures"
   gltfsource: "/3dmodels/11_plant/11_plant.gltf"
 ---
-## Chapter &#9661;:
+## Chapter &#9661;
 ### Scene 11: plant
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter2/scene12.da.md
+++ b/content/map/chapters/chapter2/scene12.da.md
@@ -9,7 +9,7 @@ params:
   textures: "/3dmodels/12_canudos/textures"
   gltfsource: "/3dmodels/12_canudos/12_canudos.gltf"
 ---
-## Kapitel &#9661;:
+## Kapitel &#9661;
 ### Scene 12: Canudos - Tututuremas Bixiga
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter2/scene12.md
+++ b/content/map/chapters/chapter2/scene12.md
@@ -9,7 +9,7 @@ params:
   textures: "/3dmodels/12_canudos/textures"
   gltfsource: "/3dmodels/12_canudos/12_canudos.gltf"
 ---
-## Chapter &#9661;:
+## Chapter &#9661;
 ### Scene 12: Canudos - Tututuremas  Bixiga
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter3/scene13.da.md
+++ b/content/map/chapters/chapter3/scene13.da.md
@@ -10,7 +10,7 @@ params:
   gltfsource: "/3dmodels/13_telescope/13_telescope.gltf"
 
 ---
-## Kapitel &#8516;:
+## Kapitel &#8516;
 ### Scene 13: Teleskop
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter3/scene13.md
+++ b/content/map/chapters/chapter3/scene13.md
@@ -10,7 +10,7 @@ params:
   gltfsource: "/3dmodels/13_telescope/13_telescope.gltf"
 
 ---
-## Chapter &#8516;:
+## Chapter &#8516;
 ### Scene 13: Telescope
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter3/scene14.da.md
+++ b/content/map/chapters/chapter3/scene14.da.md
@@ -10,7 +10,7 @@ params:
   gltfsource: "/3dmodels/14_computer_board/14_computer_board.gltf"
 
 ---
-## Kapitel &#8516;:
+## Kapitel &#8516;
 ### Scene 14: Computerkort
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter3/scene14.md
+++ b/content/map/chapters/chapter3/scene14.md
@@ -10,7 +10,7 @@ params:
   gltfsource: "/3dmodels/14_computer_board/14_computer_board.gltf"
 
 ---
-## Chapter &#8516;:
+## Chapter &#8516;
 ### Scene 14: Computer Board
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter3/scene15.da.md
+++ b/content/map/chapters/chapter3/scene15.da.md
@@ -10,7 +10,7 @@ params:
   gltfsource: "/3dmodels/15_cooking_pot/15_cooking_pot.gltf"
 
 ---
-## Kapitel &#8516;:
+## Kapitel &#8516;
 ### Scene 15: Gryde
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter3/scene15.md
+++ b/content/map/chapters/chapter3/scene15.md
@@ -10,7 +10,7 @@ params:
   gltfsource: "/3dmodels/15_cooking_pot/15_cooking_pot.gltf"
 
 ---
-## Chapter &#8516;:
+## Chapter &#8516;
 ### Scene 15: Cooking Pot
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter3/scene16.da.md
+++ b/content/map/chapters/chapter3/scene16.da.md
@@ -11,7 +11,7 @@ params:
   gltfsource: "/3dmodels/16_cobblestone/16_cobblestone.gltf"
 
 ---
-## Kapitel &#8516;:
+## Kapitel &#8516;
 ### Scene 16: Brosten
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter3/scene16.md
+++ b/content/map/chapters/chapter3/scene16.md
@@ -11,7 +11,7 @@ params:
   gltfsource: "/3dmodels/16_cobblestone/16_cobblestone.gltf"
 
 ---
-## Chapter &#8516;:
+## Chapter &#8516;
 ### Scene 16: Cobblestone
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter3/scene17.da.md
+++ b/content/map/chapters/chapter3/scene17.da.md
@@ -9,7 +9,7 @@ params:
   textures: "/3dmodels/17_chandelier/textures"
   gltfsource: "/3dmodels/17_chandelier/17_chandelier.gltf"
 ---
-## Kapitel &#8516;:
+## Kapitel &#8516;
 ### Scene 17: Antik lysekrone
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter3/scene17.md
+++ b/content/map/chapters/chapter3/scene17.md
@@ -9,7 +9,7 @@ params:
   textures: "/3dmodels/17_chandelier/textures"
   gltfsource: "/3dmodels/17_chandelier/17_chandelier.gltf"
 ---
-## Chapter &#8516;:
+## Chapter &#8516;
 ### Scene 17: Chandelier- antique
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter3/scene18.da.md
+++ b/content/map/chapters/chapter3/scene18.da.md
@@ -9,7 +9,7 @@ params:
   textures: "/3dmodels/18_brick/textures"
   gltfsource: "/3dmodels/18_brick/18_brick.gltf"
 ---
-## Chapter &#8516;:
+## Chapter &#8516;
 ### Scene 18: Mursten
 <canvas id="c"></canvas>
 

--- a/content/map/chapters/chapter3/scene18.md
+++ b/content/map/chapters/chapter3/scene18.md
@@ -9,7 +9,7 @@ params:
   textures: "/3dmodels/18_brick/textures"
   gltfsource: "/3dmodels/18_brick/18_brick.gltf"
 ---
-## Chapter &#8516;:
+## Chapter &#8516;
 ### Scene 18: Brick
 <canvas id="c"></canvas>
 


### PR DESCRIPTION
This colon really annoyed me - have removed it in all headlines.

If that's fine by you, please merge @johanne-aarup-hansen :)

![image](https://github.com/mirroringplaces/mirroringplaces.online/assets/374612/00e02f62-14a1-4f47-b92d-fa2f27fc0730)
